### PR TITLE
fix: temporary value dropped while borrowed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,9 +126,10 @@ impl<T: AsRawFd> WithFd<T> {
         out_fds: &mut Vec<OwnedFd>,
         buf: &mut [u8],
     ) -> std::io::Result<usize> {
+        let mut buf = [IoSliceMut::new(buf)];
         let recvmsg = nix::sys::socket::recvmsg::<()>(
             fd,
-            &mut [IoSliceMut::new(buf)],
+            &mut buf,
             Some(cmsg),
             nix::sys::socket::MsgFlags::empty(),
         )?;
@@ -196,8 +197,10 @@ mod test {
     };
 
     use cstr::cstr;
+    #[cfg(target_os = "linux")]
     use nix::sys::memfd::MemFdCreateFlag;
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn test_send_fd() {
         let (a, b) = std::os::unix::net::UnixStream::pair().unwrap();


### PR DESCRIPTION
Previously, with the latest compiler,

- `cargo 1.78.0-nightly (194a60b29 2024-02-21)`;
- `rustc 1.78.0-nightly (397937d81 2024-02-22)`,

`cargo release` fails with this:

```text
error[E0716]: temporary value dropped while borrowed
   --> src/lib.rs:131:18
    |
131 |             &mut [IoSliceMut::new(buf)],
    |                  ^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
...
134 |         )?;
    |           - temporary value is freed at the end of this statement
135 |         for cmsg in recvmsg.cmsgs() {
    |                     ------- borrow later used here
    |
help: consider using a `let` binding to create a longer lived value
    |
129 ~         let binding = [IoSliceMut::new(buf)];
130 ~         let recvmsg = nix::sys::socket::recvmsg::<()>(
131 |             fd,
132 ~             &mut binding,
    |
```

Nightly compiler will be stable in the future so solving this prevents breakage in the future stable compiler release.

After this change, the error will be solved and the dependents on this crate are happy.
